### PR TITLE
fixed broken docs link

### DIFF
--- a/tools/drip/fig_onboarding.sh
+++ b/tools/drip/fig_onboarding.sh
@@ -536,7 +536,7 @@ cat <<EOF
 
    ${BOLD}Want to contribute${NORMAL}?
 
-   * Check out our docs: ${UNDERLINE}https://docs.withfig.com${UNDERLINE_END}
+   * Check out our docs: ${UNDERLINE}https://withfig.com/docs/getting-started${UNDERLINE_END}
    * Submit a pull request ${UNDERLINE}https://github.com/withfig/autocomplete${UNDERLINE_END}
 
    ${BOLD}Get in touch:${NORMAL}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixed broken docs link. https://docs.withfig.com is returning a 404.

**What is the current behavior? (You can also link to an open issue here)**
404

**What is the new behavior (if this is a feature change)?**
200

**Additional info:**
n/a