### PR TITLE
Fix potential typo in "Whoops" message on the fig command onbarding step

### DIFF
--- a/tools/drip/fig_onboarding.sh
+++ b/tools/drip/fig_onboarding.sh
@@ -519,7 +519,7 @@ while true; do
       print_special "Run the ${MAGENTA}${BOLD}fig${NORMAL} command."
       print_special "(You can also type ${UNDERLINE}continue${NORMAL})"
    else
-      print_special "${YELLOW}Whoops. Looks like you tried something other Fig command."
+      print_special "${YELLOW}Whoops. Looks like you tried something other than the ${MAGENTA}${BOLD}fig${NORMAL} command."
       echo
       print_special "${BOLD}To Continue...${NORMAL}"
       print_special "Run the ${MAGENTA}${BOLD}fig${NORMAL} command."


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Onboarding flow, so Docs update?


**What is the current behavior? (You can also link to an open issue here)**

When going through onboarding, I mistyped the help flag for the `fig` command, and I found the wording on the response message a bit confusing.

<img width="479" alt="Screen Shot 2021-03-29 at 12 30 55 PM" src="https://user-images.githubusercontent.com/30241/112871210-072b5180-908d-11eb-9899-9fedaf50b49c.png">

If I misunderstood and this is the intended wording, please disregard! Just figured I'd try to help out if it's a typo.
I'm not positive on the exact wording, so I just started with the "git" command example, which uses:

```sh
  print_special "${YELLOW}Whoops. Looks like you tried something other than ${BOLD}git commit${NORMAL}."
```

#### Before this change:
> "Whoops. Looks like you tried something other Fig command"




**What is the new behavior (if this is a feature change)?**

> "Whoops. Looks like you tried something other than the **fig** command."

**Additional info:**