### PR TITLE
typo: fix typo in the README tag line

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-[Fig](https://fig.io?ref=github_fig) is reimaging the terminal, starting with [autocomplete](https://github.com/withfig/autocomplete). ✨
+[Fig](https://fig.io?ref=github_fig) is reimagining the terminal, starting with [autocomplete](https://github.com/withfig/autocomplete). ✨
 
 ![Fig Visual Autocomplete For Your Terminal Demo](https://fig.io/gifs/demo-with-header.gif)
 


### PR DESCRIPTION
fig.io says "Your terminal, reimagined" but README seems to have a typo, where it says reimaging (which does not make much sense) instead of reimagining (which is more likely to be the word that the author wanted to use).

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update

**What is the current behavior? (You can also link to an open issue here)**
No change in behavior

**What is the new behavior (if this is a feature change)?**
No change in behavior

**Additional info:**
N.A.