### PR TITLE
Add plugins link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ We make lots of products. Check out our website to see them all.
 
 - [withfig/fig](https://github.com/withfig/fig): Submit new bugs and issues
 - [withfig/autocomplete](https://github.com/withfig/autocomplete): Collection of all specs for [autocomplete](https://fig.io/docs). Contribute new specs and update old specs here.
+- [withfig/plugins](https://github.com/withfig/plugins): Collection of all plugins for [plugins](https://dashboard.fig.io/login). Contribute new plugins here.
 
 
 ## Contributing


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Add a link to the plugins repo in README.md